### PR TITLE
add minimal support of TiddlyWiki Classic

### DIFF
--- a/addon-firefox/content-script.js
+++ b/addon-firefox/content-script.js
@@ -2,7 +2,14 @@ var idGenerator = 1;
 var data = {};
 var tlast = new Date();
 var indata = {};
-// Checking if the active tab is a  local tiddlywiki file
+function injectExtensionScript(path) {
+  var script = document.createElement('script');
+  script.src = browser.extension.getURL(path); // use (browser || chrome) for cross-browser support
+  (document.head || document.documentElement).appendChild(script);
+  script.onload = script.remove;
+}
+
+// Checking if the active tab is a local tiddlywiki file
 function checkTW() {
   var results = {};
   // Test for TiddlyWiki Classic
@@ -28,14 +35,14 @@ function checkTW() {
   }
   return results;
 }
+var checkTWResults = checkTW();
+
 // Loading settings from browser storage
 var getting = browser.storage.sync.get();
 getting.then(onGot, syncError);
-
 function syncError(error) {
   console.log(`Error in getting values from browser storage: ${error}`);
 }
-
 function onGot(item) {
   data = item;
   if (data.backup == "yes") {
@@ -44,9 +51,7 @@ function onGot(item) {
   }
 }
 
-var checkTWResults = checkTW();
-
-if (checkTWResults.isTiddlyWiki5 && checkTWResults.isLocalFile) {
+if (checkTWResults.isTiddlyWiki && checkTWResults.isLocalFile) {
   var messageBox = document.getElementById("tiddlyfox-message-box");
   if (!messageBox) {
     messageBox = document.createElement("div");
@@ -127,6 +132,9 @@ if (checkTWResults.isTiddlyWiki5 && checkTWResults.isLocalFile) {
       console.log(`Error: ${error}`);
     }
   }
+}
+if (checkTWResults.isTiddlyWikiClassic && checkTWResults.isLocalFile) {
+  injectExtensionScript('patch-classic-io.js');
 }
 browser.runtime.onMessage.addListener(request => {
   console.log("Timimi: Received stdout in content-script");

--- a/addon-firefox/patch-classic-io.js
+++ b/addon-firefox/patch-classic-io.js
@@ -28,5 +28,12 @@ window.mozillaSaveFile = function(path, content) {
   return true;
 };
 
-// not necessary to track the exact version, but important to change when the overwritten methods are updated
-window.timimiClassicVersion = "2.0.2";
+// expose the supported I/O events
+window.eventBasedIO = {
+	save: {
+		name: 'tiddlyfox-save-file'
+	},
+	saved: {
+		name: 'tiddlyfox-have-saved-file'
+	}
+};

--- a/addon-firefox/patch-classic-io.js
+++ b/addon-firefox/patch-classic-io.js
@@ -1,0 +1,32 @@
+window.mozillaLoadFile = function(path) {
+  try {
+    // Just read the file synchronously
+    var xhReq = new XMLHttpRequest();
+    xhReq.open("GET", "file:///" + escape(path), false);
+    xhReq.send(null);
+    return xhReq.responseText;
+  } catch(ex) {
+    return false;
+  }
+};
+
+window.mozillaSaveFile = function(path, content) {
+  var messageBox = document.getElementById("tiddlyfox-message-box");
+  if(!messageBox) return false;
+
+  // Create the message element and put it into the message box
+  var message = document.createElement("div");
+  message.setAttribute("data-tiddlyfox-path", path);
+  message.setAttribute("data-tiddlyfox-content", content);
+  messageBox.appendChild(message);
+
+  // Create and dispatch the custom event to the extension
+  var event = document.createEvent("Events");
+  event.initEvent("tiddlyfox-save-file", true, false);
+  message.dispatchEvent(event);
+
+  return true;
+};
+
+// not necessary to track the exact version, but important to change when the overwritten methods are updated
+window.timimiClassicVersion = "2.0.2";

--- a/addon-firefox/patch-classic-io.js
+++ b/addon-firefox/patch-classic-io.js
@@ -2,7 +2,7 @@ window.mozillaLoadFile = function(path) {
   try {
     // Just read the file synchronously
     var xhReq = new XMLHttpRequest();
-    xhReq.open("GET", "file:///" + escape(path), false);
+    xhReq.open("GET", "file:///" + encodeURIComponent(path), false);
     xhReq.send(null);
     return xhReq.responseText;
   } catch(ex) {


### PR DESCRIPTION
Here's the first step for #23: add basic loading/saving support like [the plugin](https://groups.google.com/forum/#!topic/tiddlywikiclassic/TCuPSb2uMfQ) does.

Loading is synchronous, saving is async, with "false positive" return value and no callback. Timimi backuping is not supported yet (haven't figured yet what path is supposed to be added as `backupPath`, aboslute/relative, OS-styled like `C:\data\...` or web-styled like `file:///C:/data/...` or something else, with or without filename and should it be the same as the name of the backuped file). Also injects `window.timimiClassicVersion` so that plugins may act accordingly.

I'll provide further updates to this later.