### PR TITLE
Add notification on failed save

### DIFF
--- a/addon-firefox/background.js
+++ b/addon-firefox/background.js
@@ -29,6 +29,12 @@ function onResponse(response) {
 
 function onError(error) {
   console.log(`Timimi: Native Host Error: ${error}`);
+  browser.notifications.create({
+    "type": "basic",
+    "iconUrl": browser.extension.getURL("../resources/fish.png"),
+    "title": "Could not save the Tiddlywiki file",
+    "message": `Have you installed the Timimi native application?\nNative Host Error: ${error}`
+  });
 }
 
 function handleMessage(request, sender, sendResponse) {

--- a/addon-firefox/manifest.json
+++ b/addon-firefox/manifest.json
@@ -33,11 +33,12 @@
         "matches": ["file:///*"],
         "js": ["content-script.js"]
     }],
-    "options_ui": { 
-         "page": "settings/options.html" 
+    "options_ui": {
+         "page": "settings/options.html"
      },
     "permissions": [
         "nativeMessaging",
-        "storage"
+        "storage",
+        "notifications"
     ]
 }


### PR DESCRIPTION
Since saving the Tiddlywiki is very important to the user and losing the
progress made may be very impactful, the addon should tell the user if
any error has been detected.  This commit adds the "notification"
permission to manifest.json and displays a browser notification on any
error detected while sending a native message to the native application.

Since the user may save the Tiddlywiki file often, no notification is
shown in the event of a successful save: this is by design to avoid
training the user to ignore the notification.