### PR TITLE
Don't open the update page if the browser updated

### DIFF
--- a/addon-chrome/background.js
+++ b/addon-chrome/background.js
@@ -25,7 +25,8 @@ function handleMessage(request, sender, sendResponse) {
 
 chrome.runtime.onMessage.addListener(handleMessage);
 
-chrome.runtime.onInstalled.addListener(function() {
+chrome.runtime.onInstalled.addListener(details => {
+  if (details.reason == "chrome_update") return;
   chrome.tabs.create({
     url: "https://ibnishak.github.io/Timimi/#Important%3A%20Post%20Update%2FInstallation%20instructions"
   });

--- a/addon-firefox/background.js
+++ b/addon-firefox/background.js
@@ -22,6 +22,7 @@ function handleMessage(request, sender, sendResponse) {
 browser.runtime.onMessage.addListener(handleMessage);
 
 function handleInstalled(details) {
+  if (details.reason == "browser_update") return;
   console.log(details.reason);
   browser.tabs.create({
     url: "https://ibnishak.github.io/Timimi/#Important%3A%20Post%20Update%2FInstallation%20instructions"


### PR DESCRIPTION
Currently the "Upgrade Instructions" page is opened every time the browser is updated, which aside from being annoying, is also misleading since the extension itself has not updated.

I have updated the code to check the [`runtime.onInstalledReason`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnInstalledReason) before opening the new tab.