### PR TITLE
Add option for Firefox snap browser

### DIFF
--- a/installer/unix/installer.go
+++ b/installer/unix/installer.go
@@ -142,7 +142,7 @@ func findpaths(browser, platform string) (string, string) {
 	case "linuxfirefox":
 		manifestpath = ".mozilla/native-messaging-hosts"
 	case "linuxfirefox-snap":
-		manifestpath = ".mozilla/native-messaging-hosts"
+		manifestpath = "snap/firefox/common/.mozilla/native-messaging-hosts"
 	default:
 		manifestpath = ""
 		fmt.Println("Error: Installer only intended for linux and mac. Exiting")


### PR DESCRIPTION
Fixes https://github.com/ibnishak/Timimi/issues/78
The Firefox snap package requires the manifest and executable files to be relocated. This is my attempt at adding an option to select the Firefox snap browser.  Note that I have not tested it and am not sure that I've chosen the best location for the executable file.